### PR TITLE
Compatibility with upcoming pytest 5.4

### DIFF
--- a/python/pytest/freeze fixtures/conftest.py
+++ b/python/pytest/freeze fixtures/conftest.py
@@ -29,7 +29,7 @@ def pytest_fixture_setup(fixturedef, request):
 def pytest_fixture_post_finalizer(fixturedef, request):
     if not request.node.nodeid:
         return
-    if not hasattr(fixturedef, 'cached_result'):
+    if getattr(fixturedef, 'cached_result', None) is None:
         return
     file_path = construct_file_path(fixturedef, request)
     with open(file_path, 'wb') as outt:


### PR DESCRIPTION
`FixtureDef.cache_result` will be always set in pytest 5.4 (https://github.com/pytest-dev/pytest/pull/6737). This change makes it compatible when the new version is released while keeping it backward compatible.